### PR TITLE
Avoid wrapping last element if no truncation happened

### DIFF
--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -171,6 +171,21 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
     }
   },
 
+  _addWrappingSpan(truncationTargetElem) {
+    const doc = this.get('document');
+    const ellipsizedSpan = truncationTargetElem.lastChild;
+
+    truncationTargetElem.removeChild(ellipsizedSpan);
+
+    const wrappingSpan = doc.createElement('span');
+    wrappingSpan.classList.add(`${cssNamespace}--last-line-wrapper`);
+    wrappingSpan.appendChild(ellipsizedSpan);
+
+    truncationTargetElem.appendChild(wrappingSpan);
+
+    return wrappingSpan;
+  },
+
   /**
    * Does the truncation by calling the clamp utility.
    * @return {Void}
@@ -182,14 +197,14 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
     const el = this.element.querySelector(`.${cssNamespace}--truncation-target`);
     // TODO: make the assertion message more descriptive
     Ember.assert('must use the `target` component from the yielded namespace', el instanceof HTMLElement);
-    clamp(el, this.get('lines'), (didTruncate) => this.set('_isTruncated', didTruncate), `${cssNamespace}--last-line`, doc);
-    const ellipsizedSpan = el.lastChild;
-    el.removeChild(ellipsizedSpan);
-    const wrappingSpan = doc.createElement('span');
-    wrappingSpan.classList.add(`${cssNamespace}--last-line-wrapper`);
-    wrappingSpan.appendChild(ellipsizedSpan);
-    this.set('_buttonDestination', wrappingSpan);
-    el.appendChild(wrappingSpan);
+
+    clamp(el, this.get('lines'), `${cssNamespace}--last-line`, doc, (didTruncate) => {
+      this.set('_isTruncated', didTruncate);
+      if (didTruncate) {
+        this.set('_buttonDestination', this._addWrappingSpan(el));
+      }
+    });
+
     this.set('_didTruncate', true);
   },
 

--- a/addon/utils/clamp.js
+++ b/addon/utils/clamp.js
@@ -58,7 +58,7 @@ function createMeasureElement() {
   measure.style.visibility = 'hidden'; // prevent drawing
 } // function createMeasureElement
 
-export default function clamp(el, lineClamp, cb, cssClass, doc) {
+export default function clamp(el, lineClamp, cssClass, doc, cb) {
   // make sure the element belongs to the document
   if (!el.ownerDocument || el.ownerDocument !== doc) {
     return;

--- a/tests/integration/components/truncate-multiline-test.js
+++ b/tests/integration/components/truncate-multiline-test.js
@@ -183,7 +183,7 @@ test('specifying a different number of lines works', function(assert) {
   });
 });
 
-test('the button is hidden if the text isn\'t long enough to truncate', function(assert) {
+test('inline form without enough text to truncate works', function(assert) {
   this.render(hbs`
     <div style="width: 362px; font: 16px sans-serif;">
       {{truncate-multiline text="supercalifragilisticexpialidocious supercalifragilisticexpialidocious"}}
@@ -191,10 +191,18 @@ test('the button is hidden if the text isn\'t long enough to truncate', function
   `);
 
   return wait().then(() => {
+    const $truncationTarget = this.$('.truncate-multiline--truncation-target');
+    const $truncationChunks = $truncationTarget.children();
+    const $lastChunkWrapper = $truncationChunks.slice(-1);
+
     assert.equal(
       this.$('truncate-multiline--button').length,
       0,
-      'the button is not rendered'
+      'the button is hidden if the text isn\'t long enough to truncate'
+    );
+    assert.notOk(
+      $lastChunkWrapper.hasClass('truncate-multiline--last-line-wrapper'),
+      'last chunk is not wrapped if truncation was not needed'
     );
   });
 });


### PR DESCRIPTION
Motivation for this change: the last line wrapper is there to style the more/less button if truncation occurred. But if no truncation ever happened and we have no more/less button, this wrapper can actually mess up text formatting if text is center-aligned:

![screenshot 2018-11-03 11 54 56](https://user-images.githubusercontent.com/997350/47948221-4fe38c80-df5f-11e8-9b60-8fb0a7a32b25.png)

In the example above, I use `text-align: center` on the parent element but the last line wrapper has `display:flex!important` which misaligns it.