### PR TITLE
Version bump 1.0.2, Upgrade ember-diff-attrs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-truncate",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A generic component used to truncate text to a specified number of lines.",
   "keywords": [
     "ember-addon",
@@ -28,7 +28,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.4.1",
     "ember-cli-htmlbars": "^3.0.1",
-    "ember-diff-attrs": "^0.2.1",
+    "ember-diff-attrs": "^0.2.2",
     "ember-lifeline": "^3.1.1",
     "ember-singularity-mixins": "^2.1.0",
     "ember-wormhole": "^0.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,7 +2991,7 @@ ember-cli@~3.7.1:
     watch-detector "^0.1.0"
     yam "^1.0.0"
 
-ember-diff-attrs@^0.2.1:
+ember-diff-attrs@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/ember-diff-attrs/-/ember-diff-attrs-0.2.2.tgz#57baf6907957de004d9aff947809dfe78a054b3b"
   integrity sha512-dziQ8G8QVRMqSFMg2l9E+Te19kcwk7+Aad7Q8lOci2b3EAiU7s0IFB3Z8rRed0JRJ3e6mPJyRmNbyUuNoyCM8g==


### PR DESCRIPTION
Upgrades ember-diff-attrs, 
The previous version of ember-diff-attrs uses an old version of ember-weakmap. This causes problems (for me) in ember 3.4